### PR TITLE
Close #18. Duplicated "Create a task" button removed.

### DIFF
--- a/app/Resources/views/task/list.html.twig
+++ b/app/Resources/views/task/list.html.twig
@@ -29,7 +29,7 @@
         </div>
         {% else %}
             <div class="alert alert-warning" role="alert">
-                {{ 'no_registered_task'|trans }} <a href="{{ path('task_create') }}" class="btn btn-warning pull-right">{{ 'create_a_task'|trans }}</a>
+                {{ 'no_registered_task'|trans }}
             </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
Now the "Create a task" button only appears once, even if there is no existing task.