### PR TITLE
Close #37. Some files excluded from Codeclimate analysis.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,5 @@
+exclude_patterns:
+- "public/js/bootstrap.js"
+- "src/DataFixtures/"
+- "tests/"
+- "vendor/"


### PR DESCRIPTION
Exclused files and folders:
- "public/js/bootstrap.js"
- "src/DataFixtures/"
- "tests/"
- "vendor/"